### PR TITLE
Preserve separator when parsing tags

### DIFF
--- a/src/lib/default-transformer.js
+++ b/src/lib/default-transformer.js
@@ -11,12 +11,12 @@ export default function(input, {project, baseURI}) {
 
     return input
     // hashtags #tagname
-        .replace(/(?:^|\s)\#([-\w\d]{3,40})/g, function(fullTag, tagName) {
+        .replace(/(^|\s)\#([-\w\d]{3,40})/g, function(fullTag, separator, tagName) {
             if (owner && name) {
-                return `[#${tagName}](${baseURI}/projects/${owner}/${name}/talk/tags/${tagName})`
+                return `${separator}[#${tagName}](${baseURI}/projects/${owner}/${name}/talk/tags/${tagName})`
             }
             else {
-                return `[#${tagName}](${baseURI}/talk/search?query=${tagName})`
+                return `${separator}[#${tagName}](${baseURI}/talk/search?query=${tagName})`
             }
         })
 

--- a/test/lib/default-transformer-test.js
+++ b/test/lib/default-transformer-test.js
@@ -22,7 +22,7 @@ describe('default-transformer', () => {
         const sentence = `#test sentence #tag and url: http://docs.panoptes.apiary.io/#reference/user/users-collection/list-all-users`
 
         const htmlSentence = replaceSymbols(sentence, {project, baseURI})
-        expect(htmlSentence).to.equal(`[#test](/talk/search?query=test) sentence[#tag](/talk/search?query=tag) and url: http://docs.panoptes.apiary.io/#reference/user/users-collection/list-all-users`)
+        expect(htmlSentence).to.equal(`[#test](/talk/search?query=test) sentence [#tag](/talk/search?query=tag) and url: http://docs.panoptes.apiary.io/#reference/user/users-collection/list-all-users`)
     })
 
     it('ignores links with hashes', () => {


### PR DESCRIPTION
Fixes zooniverse/panoptes-front-end#2541

Apparently the non-capturing group `(?:^|\s)` is still replaced in the string, so this just captures it and re-inserts it with the link.