### PR TITLE
Add support for table-of-contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "markdown-it-imsize": "git://github.com/edpaget/markdown-it-imsize",
     "markdown-it-sub": "~1.0.0",
     "markdown-it-sup": "~1.0.0",
+    "markdown-it-table-of-contents": "~0.2.2",
     "markdown-it-video": "~0.4.0",
     "react-dom": "~0.14.1",
     "react-mixin": "~1.7.0",

--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -13,6 +13,7 @@ import markdownFootnote from 'markdown-it-footnote';
 import markdownImsize from 'markdown-it-imsize';
 import markdownNewTab from '../lib/links-in-new-tabs';
 import markdownVideo from 'markdown-it-video';
+import markdownTableOfContents from 'markdown-it-table-of-contents';
 
 const markdownIt = function () {
     return new MarkdownIt({linkify: true, breaks: true})
@@ -23,6 +24,7 @@ const markdownIt = function () {
                 .use(markdownImsize)
                 .use(markdownNewTab)
                 .use(markdownVideo)
+                .use(markdownTableOfContents)
                 .use(MarkdownItContainer, 'partners')
                 .use(MarkdownItContainer, 'attribution');
 }


### PR DESCRIPTION
Adds the table-of-contents plugin to the renderer, in response to a Talk discussion about supporting `[[toc]]` in long help documents. https://www.zooniverse.org/talk/13/18624?comment=180621