### PR TITLE
Add markdown-anchor

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "markdown-it": "~7.0.1",
+    "markdown-it-anchor": "~2.5.0",
     "markdown-it-container": "~2.0.0",
     "markdown-it-emoji": "~1.2.0",
     "markdown-it-footnote": "~3.0.1",

--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -14,6 +14,7 @@ import markdownImsize from 'markdown-it-imsize';
 import markdownNewTab from '../lib/links-in-new-tabs';
 import markdownVideo from 'markdown-it-video';
 import markdownTableOfContents from 'markdown-it-table-of-contents';
+import markdownAnchor from 'markdown-it-anchor';
 
 const markdownIt = function () {
     return new MarkdownIt({linkify: true, breaks: true})
@@ -24,6 +25,7 @@ const markdownIt = function () {
                 .use(markdownImsize)
                 .use(markdownNewTab)
                 .use(markdownVideo)
+                .use(markdownAnchor)
                 .use(markdownTableOfContents)
                 .use(MarkdownItContainer, 'partners')
                 .use(MarkdownItContainer, 'attribution');

--- a/test/components/markdown-test.js
+++ b/test/components/markdown-test.js
@@ -37,7 +37,7 @@ describe('Markdown', () => {
     describe('#markdownify', () => {
         it('renders markdown', () => {
             var md = markdown.markdownify('# test header');
-            expect(md).to.equal('<h1>test header</h1>\n');
+            expect(md).to.equal('<h1 id="test-header">test header</h1>\n');
         });
 
         it('opens links in a new tab when prefixed by +tab+', () => {


### PR DESCRIPTION
Missed this in my previous PR: `table-of-contents` uses the `anchor` plugin to create links to headings.