### PR TITLE
Fix export syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,16 @@ This package contains two publicly accessible components a Markdown viewer and a
 Viewer:
 
 ```jsx
+import { Markdown } from 'markdownz';
+
 <Markdown>{A String of `Markdown`}</Markdown>
 ```
 
 Editor:
+
 ```jsx
+import { MarkdownEditor } from 'markdownz';
+
 <MarkdownEditor rows={20} value="A String of `Markdown`" onChange={this.handleMarkdownChange} />
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,2 @@
-import Markdown from './components/markdown.jsx';
-import MarkdownEditor from './components/markdown-editor.jsx';
-
-export default {Markdown, MarkdownEditor};
-
+export { default as Markdown } from './components/markdown.jsx';
+export { default as MarkdownEditor } from './components/markdown-editor.jsx';

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,0 +1,14 @@
+import { Markdown, MarkdownEditor } from '../src/index';
+import { expect } from 'chai';
+
+describe('Exported Markdown component', () => {
+    it('should exist', () => {
+        expect(Markdown).to.be.ok;
+    });
+});
+
+describe('Exported MarkdownEditor component', () => {
+    it('should exist', () => {
+        expect(MarkdownEditor).to.be.ok;
+    });
+});


### PR DESCRIPTION
Currently, to import the markdownz modules we have to do a bit of a workaround: 

```jsx
import markdownz from 'markdownz';
const Markdown = markdownz.Markdown; // This is weird

<Markdown>{A String of `Markdown`}</Markdown>
```

This PR changes the export syntax so we can do this: 

```jsx
import { Markdown } from 'markdownz';

<Markdown>{A String of `Markdown`}</Markdown>
```

I've updated the docs, and I've added tests to make sure the named exports work properly. As the new syntax also breaks the current API, ~~I've also bumped the major version ready for release.~~ I'll wait to reversion this, as the React 15 version should be the next major version

cc @parrish @eatyourgreens @srallen 