### PR TITLE
Require spacing for @-mentions

### DIFF
--- a/src/lib/default-transformer.js
+++ b/src/lib/default-transformer.js
@@ -1,6 +1,6 @@
 const tagReplacer = /(^|\s)#([-\w\d]{3,40})/g;
-const projectSubjectLinker = /@(\b[\w-]+\b)\/(\b[\w-]+\b)\^S([0-9]+)/g;
-const subjectLinker = /\^S([0-9]+)/g;
+const projectSubjectLinker = /(^|\s)@(\b[\w-]+\b)\/(\b[\w-]+\b)\^S([0-9]+)/g;
+const subjectLinker = /(^|\s)\^S([0-9]+)/g;
 const userLinker = /(^|\s)@([\w\-.]+\b)/g;
 
 export default function (input, { project, baseURI }) {
@@ -13,7 +13,7 @@ export default function (input, { project, baseURI }) {
     [owner, name] = project.slug.split('/');
   }
 
-  const replaceProjectSubjects = `[Subject $3](${prefix}/projects/$1/$2/talk/subjects/$3)`;
+  const replaceProjectSubjects = `[Subject $4](${prefix}/projects/$2/$3/talk/subjects/$4)`;
 
   function replaceTags(fullTag, separator, tagName) {
     if (owner && name) {
@@ -29,11 +29,11 @@ export default function (input, { project, baseURI }) {
     return `${seperator}@${username}`;
   }
 
-  function replaceSubjects(_, subjectID) {
+  function replaceSubjects(_, seperator, subjectID) {
     if (owner && name) {
       const text = `Subject ${subjectID}`;
       const url = `${prefix}/projects/${owner}/${name}/talk/subjects/${subjectID}`;
-      return `[${text}](${url})`;
+      return `${seperator}[${text}](${url})`;
     }
     return subjectID;
   }

--- a/src/lib/default-transformer.js
+++ b/src/lib/default-transformer.js
@@ -1,7 +1,7 @@
 const tagReplacer = /(^|\s)#([-\w\d]{3,40})/g;
 const projectSubjectLinker = /@(\b[\w-]+\b)\/(\b[\w-]+\b)\^S([0-9]+)/g;
 const subjectLinker = /\^S([0-9]+)/g;
-const userLinker = /\B@(\b[\w-.]+\b)/g;
+const userLinker = /(^|\s)@([\w\-.]+)/g;
 
 export default function (input, { project, baseURI }) {
   let owner;
@@ -22,11 +22,11 @@ export default function (input, { project, baseURI }) {
     return `${separator}[#${tagName}](${prefix}/talk/search?query=${tagName})`;
   }
 
-  function replaceUsers(_, username) {
+  function replaceUsers(_, seperator, username) {
     if (restrictedUserNames.indexOf(username) < 0) {
-      return `[@${username}](${prefix}/users/${username})`;
+      return `${seperator}[@${username}](${prefix}/users/${username})`;
     }
-    return `@${username}`;
+    return `${seperator}@${username}`;
   }
 
   function replaceSubjects(_, subjectID) {

--- a/src/lib/default-transformer.js
+++ b/src/lib/default-transformer.js
@@ -1,7 +1,7 @@
 const tagReplacer = /(^|\s)#([-\w\d]{3,40})/g;
 const projectSubjectLinker = /@(\b[\w-]+\b)\/(\b[\w-]+\b)\^S([0-9]+)/g;
 const subjectLinker = /\^S([0-9]+)/g;
-const userLinker = /(^|\s)@([\w\-.]+)/g;
+const userLinker = /(^|\s)@([\w\-.]+\b)/g;
 
 export default function (input, { project, baseURI }) {
   let owner;

--- a/test/default-transformer-test.js
+++ b/test/default-transformer-test.js
@@ -65,6 +65,11 @@ describe('default-transformer', () => {
     expect(replaceSymbols(nonUserLink, { project, baseURI })).to.equal(nonUserLink);
   });
 
+  it('ignores trailing punctuation', () => {
+    const userLink = replaceSymbols('@test.user.', { project, baseURI });
+    expect(userLink).to.equal('[@test.user](/users/test.user).');
+  });
+
   it('it ignores restricted usernames', () => {
     const userLink = replaceSymbols('@admins @moderators @team @researchers @scientists', { project, baseURI });
     expect(userLink).to.equal('@admins @moderators @team @researchers @scientists');

--- a/test/default-transformer-test.js
+++ b/test/default-transformer-test.js
@@ -60,6 +60,11 @@ describe('default-transformer', () => {
     expect(userLink).to.equal('[@test.user](/users/test.user)');
   });
 
+  it('ignores non-separated @-names', () => {
+    const nonUserLink = 'https://www.google.com/maps/@38.3462374,-77.978685,16z';
+    expect(replaceSymbols(nonUserLink, { project, baseURI })).to.equal(nonUserLink);
+  });
+
   it('it ignores restricted usernames', () => {
     const userLink = replaceSymbols('@admins @moderators @team @researchers @scientists', { project, baseURI });
     expect(userLink).to.equal('@admins @moderators @team @researchers @scientists');


### PR DESCRIPTION
For zooniverse/panoptes-front-end#3260.

Instead of attempting to use boundary characters in the match (which never made sense here), it just requires a leading space or a line-start.

It will break mention parsing in non-spaced usages.  e.g. `"Hi @user"` works, but `"Hi (@user)"` will not