### PR TITLE
Use prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "markdown-it-sup": "~1.0.0",
     "markdown-it-table-of-contents": "~0.2.2",
     "markdown-it-video": "~0.4.0",
+    "prop-types": "~15.6.0",
     "react": "~15.6",
     "react-dom": "~15.6",
     "twemoji": "~1.4.1"

--- a/src/components/markdown-help.jsx
+++ b/src/components/markdown-help.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Markdown from './markdown';
 
 const TalkMarkdownHelp = () =>
@@ -251,8 +252,8 @@ MarkdownHelp.defaultProps = {
 };
 
 MarkdownHelp.propTypes = {
-  talk: React.PropTypes.bool,
-  title: React.PropTypes.node
+  talk: PropTypes.bool,
+  title: PropTypes.node
 };
 
 export default MarkdownHelp;


### PR DESCRIPTION
Removes `React.PropTypes` in favor of the `prop-types` package.