### PR TITLE
Only process footnote links if component is mounted

### DIFF
--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -32,9 +32,6 @@ function markdownIt() {
 }
 
 export default class Markdown extends React.Component {
-  displayName() {
-    return 'Markdown';
-  }
 
   markdownify(input) {
     Markdown.counter += 1;

--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -56,15 +56,18 @@ export default class Markdown extends React.Component {
 
   captureFootnoteLinks() {
     const backrefs = '.footnote-ref > a, .footnote-backref';
-    const links = ReactDOM.findDOMNode(this).querySelectorAll(backrefs);
+    const root = ReactDOM.findDOMNode(this);
+    if (root) {
+      const links = root.querySelectorAll(backrefs);
 
-    for (let i = 0; i < links.length; i += 1) {
-      const link = links[i];
-      const target = document.getElementById(link.getAttribute('href').replace('#', ''));
-      link.onclick = function (ev) {
-        ev.preventDefault();
-        target.scrollIntoView({ block: 'start', behavior: 'smooth' });
-      };
+      for (let i = 0; i < links.length; i += 1) {
+        const link = links[i];
+        const target = document.getElementById(link.getAttribute('href').replace('#', ''));
+        link.onclick = function (ev) {
+          ev.preventDefault();
+          target.scrollIntoView({ block: 'start', behavior: 'smooth' });
+        };
+      }
     }
   }
 

--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import MarkdownIt from 'markdown-it';
 import MarkdownItContainer from 'markdown-it-container';
 import markdownEmoji from 'markdown-it-emoji';
@@ -53,9 +52,8 @@ export default class Markdown extends React.Component {
 
   captureFootnoteLinks() {
     const backrefs = '.footnote-ref > a, .footnote-backref';
-    const root = ReactDOM.findDOMNode(this);
-    if (root) {
-      const links = root.querySelectorAll(backrefs);
+    if (this.root && this.root.querySelectorAll) {
+      const links = this.root.querySelectorAll(backrefs);
 
       for (let i = 0; i < links.length; i += 1) {
         const link = links[i];
@@ -95,7 +93,8 @@ export default class Markdown extends React.Component {
 
     return React.createElement(this.props.tag, {
       className: `markdown ${this.props.className}`,
-      dangerouslySetInnerHTML: { __html: html }
+      dangerouslySetInnerHTML: { __html: html },
+      ref: (element) => { this.root = element; }
     });
   }
 }


### PR DESCRIPTION
- Checks for a root DOM node before querying the HTML content to find footnote links.
- Removes `displayName`.
- Replaces `findDOMNode` with a ref.
