### PR TITLE
Add support for <audio> and <video>

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6711,53 +6711,15 @@
       }
     },
     "markdown-it": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-7.0.1.tgz",
-      "integrity": "sha1-8S2LiKk+ZCVDSN/Rg71wv2BWekI=",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.1.tgz",
+      "integrity": "sha512-CzzqSSNkFRUf9vlWvhK1awpJreMRqdCrBvZ8DIoDWTOkESMIF741UPAhuAmbyWmdiFPA6WARNhnu2M6Nrhwa+A==",
       "requires": {
-        "argparse": "1.0.9",
+        "argparse": "1.0.10",
         "entities": "1.1.1",
         "linkify-it": "2.0.3",
         "mdurl": "1.0.1",
-        "uc.micro": "1.0.3"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-          "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-          "requires": {
-            "sprintf-js": "1.0.3"
-          }
-        },
-        "entities": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
-        },
-        "linkify-it": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
-          "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
-          "requires": {
-            "uc.micro": "1.0.3"
-          }
-        },
-        "mdurl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-          "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-        },
-        "uc.micro": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz",
-          "integrity": "sha1-ftUNXg+an7ClczeSWfKndFjVAZI="
-        }
+        "uc.micro": "1.0.5"
       }
     },
     "markdown-it-anchor": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -3906,6 +3914,11 @@
         "iconv-lite": "0.4.19"
       }
     },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+    },
     "enzyme": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.8.2.tgz",
@@ -6681,6 +6694,14 @@
         }
       }
     },
+    "linkify-it": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
+      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
+      "requires": {
+        "uc.micro": "1.0.5"
+      }
+    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
@@ -6768,6 +6789,29 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.1.tgz",
       "integrity": "sha1-fzcwdHysyG4v4L+KF6cQ80eRUXo="
+    },
+    "markdown-it-html5-embed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-html5-embed/-/markdown-it-html5-embed-1.0.0.tgz",
+      "integrity": "sha512-SPgugO/1+/9sZcgxoxijoTHSUpCUgFCNe1MSuTmDxDkV6NQrVzMclhRMFgE/rcHO+2rhIg3U7Oy80XA/E8ytpg==",
+      "requires": {
+        "markdown-it": "8.4.1",
+        "mimoza": "1.0.0"
+      },
+      "dependencies": {
+        "markdown-it": {
+          "version": "8.4.1",
+          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.1.tgz",
+          "integrity": "sha512-CzzqSSNkFRUf9vlWvhK1awpJreMRqdCrBvZ8DIoDWTOkESMIF741UPAhuAmbyWmdiFPA6WARNhnu2M6Nrhwa+A==",
+          "requires": {
+            "argparse": "1.0.10",
+            "entities": "1.1.1",
+            "linkify-it": "2.0.3",
+            "mdurl": "1.0.1",
+            "uc.micro": "1.0.5"
+          }
+        }
+      }
     },
     "markdown-it-imsize": {
       "version": "2.0.1",
@@ -6878,6 +6922,24 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/markdown-it-video/-/markdown-it-video-0.4.0.tgz",
       "integrity": "sha1-H1GjRxRWolCaOCDc7ZrRzpYb22Q="
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mimoza": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mimoza/-/mimoza-1.0.0.tgz",
+      "integrity": "sha1-10qk/giTLwBeQwvce/z6lfyrTmI=",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
     },
     "mocha": {
       "version": "3.1.2",
@@ -7216,6 +7278,11 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
     "twemoji": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-1.4.1.tgz",
@@ -7225,6 +7292,11 @@
       "version": "0.7.17",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+    },
+    "uc.micro": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
+      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg=="
     },
     "whatwg-fetch": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-test-renderer": "~15.6"
   },
   "dependencies": {
-    "markdown-it": "~7.0.1",
+    "markdown-it": "~8.4.1",
     "markdown-it-anchor": "~2.5.0",
     "markdown-it-container": "~2.0.0",
     "markdown-it-emoji": "~1.2.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "markdown-it-container": "~2.0.0",
     "markdown-it-emoji": "~1.2.0",
     "markdown-it-footnote": "~3.0.1",
+    "markdown-it-html5-embed": "~1.0.0",
     "markdown-it-imsize": "~2.0.1",
     "markdown-it-sub": "~1.0.0",
     "markdown-it-sup": "~1.0.0",

--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -10,6 +10,8 @@ import markdownVideo from 'markdown-it-video';
 import markdownTableOfContents from 'markdown-it-table-of-contents';
 import markdownAnchor from 'markdown-it-anchor';
 import twemoji from 'twemoji';
+import html5Embed from 'markdown-it-html5-embed';
+
 
 import replaceSymbols from '../lib/default-transformer';
 import relNofollow from '../lib/links-rel-nofollow';
@@ -27,7 +29,8 @@ function markdownIt() {
     .use(markdownAnchor)
     .use(markdownTableOfContents)
     .use(MarkdownItContainer, 'partners')
-    .use(MarkdownItContainer, 'attribution');
+    .use(MarkdownItContainer, 'attribution')
+    .use(html5Embed, {});
 }
 
 export default class Markdown extends React.Component {


### PR DESCRIPTION
Adds [markdown-it-html5-embed](https://www.npmjs.com/package/markdown-it-html5-embed), which allows audio and video files to be embedded by using the standard Markdown image syntax.

Closes #65.