### PR TITLE
Add noopener nofollow with target=_blank

### DIFF
--- a/src/lib/links-in-new-tabs.js
+++ b/src/lib/links-in-new-tabs.js
@@ -14,12 +14,18 @@ export default function(md, opts) {
     if (prefix === href.slice(0, prefix.length)) {
       // trim prefix if href starts with prefix
       tokens[idx].attrs[hrefIndex][1] = href.slice(prefix.length, href.length);
-      const aIndex = tokens[idx].attrIndex('target');
+      var aIndex = tokens[idx].attrIndex('target');
+      var rIndex = tokens[idx].attrIndex('ref');
 
       if (aIndex < 0) {
         tokens[idx].attrPush(['target', '_blank']); // add new attribute
       } else {
-        tokens[idx].attrs[aIndex][1] = '_blank';  // replace value of existing attr
+        tokens[idx].attrs[aIndex][1] = '_blank'; // replace value of existing attr
+      }
+      if (rIndex < 0) {
+        tokens[idx].attrPush(['ref', 'noopener nofollow'])
+      } else {
+        tokens[idx].attrs[rIndex][1] = 'noopener nofollow';
       }
     }
 

--- a/test/links-in-new-tabs-test.js
+++ b/test/links-in-new-tabs-test.js
@@ -8,13 +8,13 @@ describe('links-in-new-tabs', () => {
   });
 
   it('opens links prefixed with +tab+ in a _blank target by default', () => {
-    const md = mdIt.renderInline('[Test](+tab+http://www.example.com)');
-    expect(md).to.equal('<a href="http://www.example.com" target="_blank">Test</a>');
+    const md = mdIt.renderInline('[Test](+tab+https://www.example.com)');
+    expect(md).to.equal('<a href="https://www.example.com" target="_blank" ref="noopener nofollow">Test</a>');
   });
 
   it('renders normal links without a new tab prefix', () => {
-    const md = mdIt.renderInline('[Test](http://www.example.com)');
-    expect(md).to.equal('<a href="http://www.example.com">Test</a>');
+    const md = mdIt.renderInline('[Test](https://www.example.com)');
+    expect(md).to.equal('<a href="https://www.example.com">Test</a>');
   });
 
   it('accepts a customizable prefix', () => {
@@ -25,7 +25,7 @@ describe('links-in-new-tabs', () => {
       prefix: '=newtab='
     });
 
-    const md = mdIt.renderInline('[Test](=newtab=http://www.example.com)');
-    expect(md).to.equal('<a href="http://www.example.com" target="_blank">Test</a>');
+    const md = mdIt.renderInline('[Test](=newtab=https://www.example.com)');
+    expect(md).to.equal('<a href="https://www.example.com" target="_blank" ref="noopener nofollow">Test</a>');
   });
 });

--- a/test/markdown-test.jsx
+++ b/test/markdown-test.jsx
@@ -34,7 +34,7 @@ describe('Markdown', () => {
 
     it('opens links in a new tab when prefixed by +tab+', () => {
       const md = markdown.markdownify('[A link](+tab+http://www.google.com)');
-      expect(md).to.equal('<p><a href="http://www.google.com" target="_blank">A link</a></p>\n');
+      expect(md).to.equal('<p><a href="http://www.google.com" target="_blank" ref="noopener nofollow">A link</a></p>\n');
     });
   });
 


### PR DESCRIPTION
Add ref="noopener nofollow" when using target=_blank, to prevent the destination window from accessing window.opener on the calling window. https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/