### PR TITLE
Add noreferrer to untrusted links

### DIFF
--- a/src/lib/links-in-new-tabs.js
+++ b/src/lib/links-in-new-tabs.js
@@ -15,7 +15,7 @@ export default function(md, opts) {
       // trim prefix if href starts with prefix
       tokens[idx].attrs[hrefIndex][1] = href.slice(prefix.length, href.length);
       var aIndex = tokens[idx].attrIndex('target');
-      var rIndex = tokens[idx].attrIndex('ref');
+      var rIndex = tokens[idx].attrIndex('rel');
 
       if (aIndex < 0) {
         tokens[idx].attrPush(['target', '_blank']); // add new attribute
@@ -23,9 +23,11 @@ export default function(md, opts) {
         tokens[idx].attrs[aIndex][1] = '_blank'; // replace value of existing attr
       }
       if (rIndex < 0) {
-        tokens[idx].attrPush(['ref', 'noopener nofollow'])
+        tokens[idx].attrPush(['rel', 'noopener nofollow noreferrer'])
       } else {
-        tokens[idx].attrs[rIndex][1] = 'noopener nofollow';
+        tokens[idx].attrs[rIndex].push('noopener');
+        tokens[idx].attrs[rIndex].push('nofollow');
+        tokens[idx].attrs[rIndex].push('noreferrer');
       }
     }
 

--- a/src/lib/links-rel-nofollow.js
+++ b/src/lib/links-rel-nofollow.js
@@ -11,11 +11,12 @@ export default function(md) {
     const relIndex = tokens[idx].attrIndex('rel');
 
     if (!href.match(/zooniverse.org/)) {
-      // add rel=nofollow to external links
+      // add rel=nofollow noreferrer to external links
       if (relIndex < 0) {
-        tokens[idx].attrPush(['rel', 'nofollow']);
+        tokens[idx].attrPush(['rel', 'nofollow noreferrer']);
       } else {
-        tokens[idx].attrs[relIndex][1] = 'nofollow';
+        tokens[idx].attrs[relIndex].push('nofollow');
+        tokens[idx].attrs[relIndex].push('noreferrer');
       }
     }
 

--- a/test/links-in-new-tabs-test.js
+++ b/test/links-in-new-tabs-test.js
@@ -9,7 +9,7 @@ describe('links-in-new-tabs', () => {
 
   it('opens links prefixed with +tab+ in a _blank target by default', () => {
     const md = mdIt.renderInline('[Test](+tab+https://www.example.com)');
-    expect(md).to.equal('<a href="https://www.example.com" target="_blank" ref="noopener nofollow">Test</a>');
+    expect(md).to.equal('<a href="https://www.example.com" target="_blank" rel="noopener nofollow noreferrer">Test</a>');
   });
 
   it('renders normal links without a new tab prefix', () => {
@@ -26,6 +26,6 @@ describe('links-in-new-tabs', () => {
     });
 
     const md = mdIt.renderInline('[Test](=newtab=https://www.example.com)');
-    expect(md).to.equal('<a href="https://www.example.com" target="_blank" ref="noopener nofollow">Test</a>');
+    expect(md).to.equal('<a href="https://www.example.com" target="_blank" rel="noopener nofollow noreferrer">Test</a>');
   });
 });

--- a/test/links-rel-nofollow-test.js
+++ b/test/links-rel-nofollow-test.js
@@ -7,9 +7,9 @@ describe('links-rel-nofollow', () => {
     mdIt = new MarkdownIt({ linkify: true, breaks: true }).use(relNofollow);
   });
 
-  it('adds rel=nofollow to links', () => {
+  it('adds rel=nofollow noreferrer to links', () => {
     const md = mdIt.renderInline('[Example Link](http://www.example.org)');
-    expect(md).to.equal('<a href="http://www.example.org" rel="nofollow">Example Link</a>');
+    expect(md).to.equal('<a href="http://www.example.org" rel="nofollow noreferrer">Example Link</a>');
   });
 
   it('does not add a rel=nofollow attr to zooniverse.org links', () => {

--- a/test/markdown-test.jsx
+++ b/test/markdown-test.jsx
@@ -34,7 +34,7 @@ describe('Markdown', () => {
 
     it('opens links in a new tab when prefixed by +tab+', () => {
       const md = markdown.markdownify('[A link](+tab+http://www.google.com)');
-      expect(md).to.equal('<p><a href="http://www.google.com" target="_blank" ref="noopener nofollow">A link</a></p>\n');
+      expect(md).to.equal('<p><a href="http://www.google.com" target="_blank" rel="noopener nofollow noreferrer">A link</a></p>\n');
     });
   });
 
@@ -60,7 +60,7 @@ describe('Markdown', () => {
   describe('#renderer', () => {
     it('uses relNofollow when passed as a prop', () => {
       const md = TestUtils.renderIntoDocument(React.createElement(Markdown, { className: 'MyComponent', relNofollow: true }, '[Test](link)'));
-      expect(md.getHtml()).to.equal('<p><a href="link" rel="nofollow">Test</a></p>\n');
+      expect(md.getHtml()).to.equal('<p><a href="link" rel="nofollow noreferrer">Test</a></p>\n');
     });
 
     it('doesn\'t use relNofollow when not passed as a prop', () => {


### PR DESCRIPTION
Fix a bug where links are written with a ref attribute, instead of rel.
Add rel=noreferrer to links all external links, in addition to rel=nofollow.

Closes https://github.com/zooniverse/how-to-zooniverse/issues/143