### PR TITLE
Update link to supported emojis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [v7.10.0](https://github.com/zooniverse/markdownz/tree/v7.9.0) (2022-12-12)
+## Pending Release
+
+**Closed issues:**
+
+- Update link to supported emoji [\#127](https://github.com/zooniverse/markdownz/issues/127)
+
+## [v7.10.0](https://github.com/zooniverse/markdownz/tree/v7.10.0) (2022-12-12)
 
 **Merged pull requests:**
 

--- a/src/components/markdown-help.jsx
+++ b/src/components/markdown-help.jsx
@@ -41,7 +41,7 @@ const TalkMarkdownHelp = () =>
       </tr>
       <tr>
         <td>Complete<br />Emoji List</td>
-        <td><a href="http://www.emoji-cheat-sheet.com/" rel="noopener noreferrer" target="_blank">use this website for all supported emoji</a></td>
+        <td><a href="https://www.webfx.com/tools/emoji-cheat-sheet/" rel="noopener noreferrer" target="_blank">use this website for all supported emoji</a></td>
       </tr>
     </tbody>
   </table>);


### PR DESCRIPTION
Closes #127 by updating the link in markdown-help.jsx.