### PR TITLE
use new base url for twemoji

### DIFF
--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -87,7 +87,7 @@ export default class Markdown extends React.Component {
   }
 
   emojify(input) {
-    return twemoji.parse(input);
+    return twemoji.parse(input, { base: 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/' });
   }
 
   render() {


### PR DESCRIPTION
max CDN is shut down, this uses a temporary URL till the more permanent fix is available as an NPM install. 

Details at https://github.com/twitter/twemoji/issues/580

Once merged - This will have to be released as a markdownz package and then installed to PFE etc