### PR TITLE
Add a useMarkdownz hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased](https://github.com/zooniverse/markdownz/tree/master) (2023-10-30)
+Add a `useMarkdownz` hook.
+
+**Full Changelog**: https://github.com/zooniverse/markdownz/compare/v8.4.1...master
+
 ## [v8.4.1](https://github.com/zooniverse/markdownz/tree/v8.4.1) (2023-10-24)
 Dependency updates. Upgrade ESLint from 4 to 8.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ This is a test [with a link](https://www.zooniverse.org).
 const html = utils.getHTML({ content });
 ```
 
+Hooks:
+
+The `useMarkdownz` hook accepts the same props as the `Markdown` component. It returns the parsed content as HTML.
+
+```js
+import { useMarkdownz } from 'markdownz';
+
+const html = useMarkdownz({ content: 'This is some markdown', debug: true })
+```
+
 ## Supported Properties
 
 ### Viewer
@@ -61,6 +71,7 @@ const html = utils.getHTML({ content });
 |----------|:-------:|--------|
 | children  | `null` | Markdown String to Render |
 | content | `''` | Markdown String to Render used if `this.props.children` is null |
+| debug | `false` | Return error messages, if true, for easier debugging |
 | tag | `div` | HTML tag to wrap markdown content with |
 | className | `''` | css classes for the element |
 | project | `null` | Panoptes project for links |

--- a/src/hooks/use-markdownz.js
+++ b/src/hooks/use-markdownz.js
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+
+import * as utils from '../lib/utils';
+import replaceSymbols from '../lib/default-transformer';
+
+export default function useMarkdownz({
+  baseURI,
+  content,
+  debug = false,
+  idPrefix,
+  inline = false,
+  project,
+  relNoFollow = false,
+  transform = replaceSymbols
+}) {
+  return useMemo(() => utils.getHtml({
+    baseURI,
+    content,
+    debug,
+    idPrefix,
+    inline,
+    project,
+    relNoFollow,
+    transform
+  }));
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,3 +2,4 @@ export { default as Markdown } from './components/markdown';
 export { default as MarkdownEditor } from './components/markdown-editor';
 export { default as MarkdownHelp } from './components/markdown-help';
 export * as utils from './lib/utils';
+export { default as useMarkdownz } from './hooks/use-markdownz';

--- a/test/use-markdownz-test.js
+++ b/test/use-markdownz-test.js
@@ -1,0 +1,85 @@
+import { Component } from 'react';
+import TestUtils from 'react-dom/test-utils';
+
+import useMarkdownz from '../src/hooks/use-markdownz';
+
+function MarkdownStub({ children, ...props }) {
+  const html = useMarkdownz({ content: children, ...props });
+  return (
+    <div
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+class TestComponent extends Component {
+  render() {
+    return <MarkdownStub {...this.props} />;
+  }
+}
+
+describe('useMarkdownz', () => {
+  const errorTransform = () => {
+    throw new Error('fail');
+  };
+
+  it('returns the formatted html', () => {
+    const md = TestUtils.renderIntoDocument(
+      <TestComponent>
+        Test text
+      </TestComponent>
+    );
+    const markdownDiv = TestUtils.findRenderedDOMComponentWithTag(md, 'div');
+    expect(markdownDiv.innerHTML).to.equal('<p>Test text</p>\n');
+  });
+
+  it('renders bare child content on error', () => {
+    const md = TestUtils.renderIntoDocument(
+      <TestComponent transform={errorTransform}>
+        Test text
+      </TestComponent>
+    );
+    const markdownDiv = TestUtils.findRenderedDOMComponentWithTag(md, 'div');
+    expect(markdownDiv.innerHTML).to.equal('Test text');
+  });
+
+  it('uses relNofollow when passed as a prop', () => {
+    const md = TestUtils.renderIntoDocument(
+      <TestComponent relNoFollow>
+        [Test](link)
+      </TestComponent>
+    );
+    const markdownDiv = TestUtils.findRenderedDOMComponentWithTag(md, 'div');
+    expect(markdownDiv.innerHTML).to.equal('<p><a rel="nofollow noreferrer" href="link">Test</a></p>\n');
+  });
+
+  it('doesn\'t use relNofollow when not passed as a prop', () => {
+    const md = TestUtils.renderIntoDocument(
+      <TestComponent>
+        [Test](link)
+      </TestComponent>
+    );
+    const markdownDiv = TestUtils.findRenderedDOMComponentWithTag(md, 'div');
+    expect(markdownDiv.innerHTML).to.equal('<p><a href="link">Test</a></p>\n');
+  });
+
+  it('opens +tab+ links in a new tab', function () {
+    const md = TestUtils.renderIntoDocument(
+      <TestComponent inline>
+        [Test](+tab+https://www.example.com)
+      </TestComponent>
+    );
+    const markdownDiv = TestUtils.findRenderedDOMComponentWithTag(md, 'div');
+    expect(markdownDiv.innerHTML).to.equal('<a rel="noopener nofollow noreferrer" target="_blank" href="https://www.example.com">Test</a>');
+  });
+
+  it('embeds YoutTube videos with modified image syntax', function () {
+    const md = TestUtils.renderIntoDocument(
+      <TestComponent inline>
+        @[youtube](dQw4w9WgXcQ)
+      </TestComponent>
+    );
+    const markdownDiv = TestUtils.findRenderedDOMComponentWithTag(md, 'div');
+    expect(markdownDiv.innerHTML).to.equal('<div class="embed-responsive embed-responsive-16by9"><iframe allowfullscreen="" src="https://www.youtube.com/embed/dQw4w9WgXcQ" height="390" width="640" type="text/html" class="embed-responsive-item youtube-player"></iframe></div>');
+  });
+});


### PR DESCRIPTION
Add a `useMarkdownz` hook, which can be used in functional components:
```js
import { useMarkdownz } from 'markdownz';
const html = useMarkdownz(markdown);
```