### PR TITLE
Add utils.getComponentTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,24 @@
 # Changelog
 
 ## [Unreleased](https://github.com/zooniverse/markdownz/tree/master) (2023-10-30)
-Refactor the Rehype code into `utils.getComponentTree`.
+- Refactor `Markdownz` as a functional component.
+- Refactor the Rehype code into `utils.getComponentTree`.
+- Return a React component tree from the `useMarkdownz` hook.
+
+```jsx
+// render HTML as JSX
+import { utils } from 'markdownz';
+const html = '<p>This is a test paragraph, with <a href="https://www.zooniverse.org">a link.</a>';
+const reactChildren = utils.getComponentTree({ html });
+return <div>{reactChildren}</div>;
+```
+
+```jsx
+import { useMarkdownz } from 'markdownz';
+
+const markdownChildren = useMarkdownz({ content: 'This is some markdown', debug: true });
+return <>{markdownChildren}</>;
+```
 
 **Full Changelog**: https://github.com/zooniverse/markdownz/compare/v9.0.0...master
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased](https://github.com/zooniverse/markdownz/tree/master) (2023-10-30)
+Refactor the Rehype code into `utils.getComponentTree`.
+
+**Full Changelog**: https://github.com/zooniverse/markdownz/compare/v9.0.0...master
+
 ## [v9.0.0](https://github.com/zooniverse/markdownz/tree/v9.0.0) (2023-10-30)
 Remove `dangerouslySetInnerHTML`. Render the HTML output with `rehype-react`.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ This is a test [with a link](https://www.zooniverse.org).
 const html = utils.getHTML({ content });
 ```
 
+```jsx
+// render HTML as JSX with utils.getComponentTree
+import { utils } from 'markdownz';
+const html = '<p>This is a test paragraph, with <a href="https://www.zooniverse.org">a link.</a>';
+const markdownChildren = utils.getComponentTree({ html });
+return <div>{markdownChildren}</div>;
+```
+
 Hooks:
 
 The `useMarkdownz` hook accepts the same props as the `Markdown` component. It returns the parsed content as HTML.

--- a/README.md
+++ b/README.md
@@ -65,12 +65,13 @@ return <div>{markdownChildren}</div>;
 
 Hooks:
 
-The `useMarkdownz` hook accepts the same props as the `Markdown` component. It returns the parsed content as HTML.
+The `useMarkdownz` hook accepts the same props as the `Markdown` component. It returns the parsed content as a React component tree, which can be rendered as JSX or with `React.createElement`;
 
-```js
+```jsx
 import { useMarkdownz } from 'markdownz';
 
-const html = useMarkdownz({ content: 'This is some markdown', debug: true })
+const markdownChildren = useMarkdownz({ content: 'This is some markdown', debug: true });
+return <>{markdownChildren}</>;
 ```
 
 ## Supported Properties

--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -1,4 +1,4 @@
-import { PureComponent, createElement } from 'react';
+import { PureComponent } from 'react';
 
 import * as utils from '../lib/utils';
 
@@ -21,13 +21,13 @@ export default class Markdown extends PureComponent {
   }
 
   render() {
-    const { className, children, components, content, settings, tag, ...props } = this.props;
+    const { className, children, components, content, settings, tag: Tag, ...props } = this.props;
     const html = utils.getHtml({
       ...props,
       content: children || content
     });
 
-    const parsedHTML = utils.getComponentTree({
+    const reactChildren = utils.getComponentTree({
       components,
       html,
       settings
@@ -35,11 +35,14 @@ export default class Markdown extends PureComponent {
 
     setTimeout(() => this.captureFootnoteLinks(), 1);
 
-    return createElement(tag, {
-      className: `markdown ${className}`,
-      children: parsedHTML,
-      ref: (element) => { this.root = element; }
-    });
+    return (
+      <Tag
+        ref={(element) => { this.root = element; }}
+        className={`markdown ${className}`}
+      >
+        {reactChildren}
+      </Tag>
+    );
   }
 }
 

--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -1,6 +1,4 @@
-import { Fragment, PureComponent, createElement } from 'react';
-import rehype from 'rehype';
-import rehype2react from 'rehype-react';
+import { PureComponent, createElement } from 'react';
 
 import * as utils from '../lib/utils';
 
@@ -28,26 +26,14 @@ export default class Markdown extends PureComponent {
       ...props,
       content: children || content
     });
+
+    const parsedHTML = utils.getComponentTree({
+      components,
+      html,
+      settings
+    });
+
     setTimeout(() => this.captureFootnoteLinks(), 1);
-
-    const rehypeSettings = {
-      fragment: true,
-      ...settings
-    };
-
-    let parsedHTML = null;
-    try {
-      parsedHTML = rehype()
-        .data('settings', rehypeSettings)
-        .use(rehype2react, {
-          Fragment,
-          createElement,
-          components
-        })
-        .processSync(html).result;
-    } catch (error) {
-      parsedHTML = error.message;
-    }
 
     return createElement(tag, {
       className: `markdown ${className}`,

--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 
-import * as utils from '../lib/utils';
+import useMarkdownz from '../hooks/use-markdownz';
 import replaceSymbols from '../lib/default-transformer';
 
 export default function Markdown({
@@ -37,21 +37,17 @@ export default function Markdown({
     }
   }
 
-  const html = utils.getHtml({
+  const reactChildren = useMarkdownz({
     baseURI,
+    components,
     content: children || content,
     debug,
     idPrefix,
     inline,
     project,
     relNoFollow,
+    settings,
     transform
-  });
-
-  const reactChildren = utils.getComponentTree({
-    components,
-    html,
-    settings
   });
 
   setTimeout(captureFootnoteLinks, 1);

--- a/src/hooks/use-markdownz.js
+++ b/src/hooks/use-markdownz.js
@@ -5,15 +5,17 @@ import replaceSymbols from '../lib/default-transformer';
 
 export default function useMarkdownz({
   baseURI,
+  components = null,
   content,
   debug = false,
   idPrefix,
   inline = false,
   project,
   relNoFollow = false,
+  settings = {},
   transform = replaceSymbols
 }) {
-  return useMemo(() => utils.getHtml({
+  const html = useMemo(() => utils.getHtml({
     baseURI,
     content,
     debug,
@@ -22,5 +24,11 @@ export default function useMarkdownz({
     project,
     relNoFollow,
     transform
+  }));
+
+  return useMemo(() => utils.getComponentTree({
+    components,
+    html,
+    settings
   }));
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -12,6 +12,10 @@ import html5Embed from 'markdown-it-html5-embed';
 import twemoji from '@twemoji/api';
 import { sanitize } from 'isomorphic-dompurify';
 
+import { Fragment, createElement } from 'react';
+import rehype from 'rehype';
+import rehype2react from 'rehype-react';
+
 import markdownNewTab from './links-in-new-tabs';
 import relNofollow from './links-rel-nofollow';
 import replaceSymbols from './default-transformer';
@@ -92,4 +96,26 @@ export function getHtml({
     }
     return content;
   }
+}
+
+export function getComponentTree({ html, settings, components }) {
+  const rehypeSettings = {
+    fragment: true,
+    ...settings
+  };
+
+  let parsedHTML = null;
+  try {
+    parsedHTML = rehype()
+      .data('settings', rehypeSettings)
+      .use(rehype2react, {
+        Fragment,
+        createElement,
+        components
+      })
+      .processSync(html).result;
+  } catch (error) {
+    parsedHTML = error.message;
+  }
+  return parsedHTML
 }

--- a/test/markdown-test.jsx
+++ b/test/markdown-test.jsx
@@ -1,33 +1,21 @@
-import { createElement } from 'react';
+import { createElement, PureComponent } from 'react';
 import TestUtils from 'react-dom/test-utils';
 import { Markdown } from '../src/index';
-import * as utils from '../src/lib/utils';
 
 describe('Markdown', () => {
+  class TestWrapper extends PureComponent {
+    render() {
+      return <Markdown {...this.props} />;
+    }
+  }
   let markdown;
 
   beforeEach(() => {
-    markdown = TestUtils.renderIntoDocument(<Markdown />);
+    markdown = TestUtils.renderIntoDocument(<TestWrapper />);
   });
 
   it('exists', () => {
     expect(markdown).to.be.ok;
-  });
-
-  it('#getDefaultProps', () => {
-    expect(Markdown.defaultProps).to.deep.equal({
-      tag: 'div',
-      components: null,
-      content: '',
-      debug: false,
-      inline: false,
-      project: null,
-      settings: {},
-      baseURI: null,
-      className: '',
-      relNofollow: false,
-      idPrefix: null
-    });
   });
 
   describe('#render', () => {
@@ -35,7 +23,7 @@ describe('Markdown', () => {
     let md;
 
     before(() => {
-      editor = createElement(Markdown, {
+      editor = createElement(TestWrapper, {
         className: 'MyComponent',
         tag: 'div',
         transform: (html => html.replace('foo', 'bar'))
@@ -49,17 +37,14 @@ describe('Markdown', () => {
       expect(markdownDiv.innerHTML).to.equal('<p>Test children bar</p>\n');
     });
 
-    it('calls getHtml in render', () => {
-      const getHtmlSpy = spy.on(utils, 'getHtml');
-      md.render();
-      expect(getHtmlSpy).to.have.been.called();
-    });
-
     it('returns a react component, with customizable tag', () => {
-      const ed = createElement(Markdown, { className: 'PMarkdown', tag: 'p' }, 'Test p tag');
+      const ed = createElement(TestWrapper, { className: 'PMarkdown', tag: 'p', inline: true }, 'Test p tag');
       const mdEditor = TestUtils.renderIntoDocument(ed);
       const renderValue = mdEditor.render();
-      expect(renderValue.type).to.equal('p');
+      expect(renderValue.type).to.equal(Markdown);
+      const markdownP = TestUtils.findRenderedDOMComponentWithTag(mdEditor, 'p');
+      expect(markdownP.getAttribute('class')).to.equal('markdown PMarkdown');
+      expect(markdownP.innerHTML).to.equal('Test p tag');
     });
   });
 });

--- a/test/use-markdownz-test.js
+++ b/test/use-markdownz-test.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { PureComponent } from 'react';
 import TestUtils from 'react-dom/test-utils';
 
 import useMarkdownz from '../src/hooks/use-markdownz';
@@ -6,13 +6,13 @@ import useMarkdownz from '../src/hooks/use-markdownz';
 function MarkdownStub({ children, ...props }) {
   const html = useMarkdownz({ content: children, ...props });
   return (
-    <div
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
+    <div className="testStub">
+      {html}
+    </div>
   );
 }
 
-class TestComponent extends Component {
+class TestComponent extends PureComponent {
   render() {
     return <MarkdownStub {...this.props} />;
   }
@@ -79,7 +79,7 @@ describe('useMarkdownz', () => {
         @[youtube](dQw4w9WgXcQ)
       </TestComponent>
     );
-    const markdownDiv = TestUtils.findRenderedDOMComponentWithTag(md, 'div');
+    const markdownDiv = TestUtils.findRenderedDOMComponentWithClass(md, 'testStub');
     expect(markdownDiv.innerHTML).to.equal('<div class="embed-responsive embed-responsive-16by9"><iframe allowfullscreen="" src="https://www.youtube.com/embed/dQw4w9WgXcQ" height="390" width="640" type="text/html" class="embed-responsive-item youtube-player"></iframe></div>');
   });
 });


### PR DESCRIPTION
Refactor `Markdown` as a functional component.

Refactor the Rehype code into `utils.getComponentTree({ components, html, settings })`.

Return a React component tree from the `useMarkdownz` hook.

```jsx
// render HTML as JSX
import { utils } from 'markdownz';
const html = '<p>This is a test paragraph, with <a href="https://www.zooniverse.org">a link.</a>';
const reactChildren = utils.getComponentTree({ html });
return <div>{reactChildren}</div>;
```

```jsx
import { useMarkdownz } from 'markdownz';

const markdownChildren = useMarkdownz({ content: 'This is some markdown', debug: true });
return <>{markdownChildren}</>;
```