### PR TITLE
Optimise Markdown and useMarkdownz

### DIFF
--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -1,20 +1,23 @@
+import PropTypes from 'prop-types';
 import { useRef } from 'react';
 
 import useMarkdownz from '../hooks/use-markdownz';
 import replaceSymbols from '../lib/default-transformer';
 
+const defaultSettings = {};
+
 export default function Markdown({
-  baseURI = null,
+  baseURI = '',
   className = '',
-  children,
+  children = null,
   components = null,
   content = '',
   debug = false,
-  idPrefix = null,
+  idPrefix = '',
   inline = false,
   project = null,
   relNoFollow = false,
-  settings = {},
+  settings = defaultSettings,
   tag = 'div',
   transform = replaceSymbols
 }) {
@@ -63,3 +66,21 @@ export default function Markdown({
 }
 
 Markdown.counter = 0;
+
+Markdown.propTypes = {
+  baseURI: PropTypes.string,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  components: PropTypes.object,
+  content: PropTypes.string,
+  debug: PropTypes.bool,
+  idPrefix: PropTypes.string,
+  inline: PropTypes.bool,
+  project: PropTypes.shape({
+    slug: PropTypes.string
+  }),
+  relNoFollow: PropTypes.bool,
+  settings: PropTypes.object,
+  tag: PropTypes.string,
+  transform: PropTypes.func
+};

--- a/src/hooks/use-markdownz.js
+++ b/src/hooks/use-markdownz.js
@@ -3,16 +3,18 @@ import { useMemo } from 'react';
 import * as utils from '../lib/utils';
 import replaceSymbols from '../lib/default-transformer';
 
+const defaultSettings = {};
+
 export default function useMarkdownz({
-  baseURI,
+  baseURI = '',
   components = null,
-  content,
+  content = '',
   debug = false,
-  idPrefix,
+  idPrefix = '',
   inline = false,
-  project,
+  project = null,
   relNoFollow = false,
-  settings = {},
+  settings = defaultSettings,
   transform = replaceSymbols
 }) {
   const html = useMemo(() => utils.getHtml({
@@ -24,11 +26,11 @@ export default function useMarkdownz({
     project,
     relNoFollow,
     transform
-  }));
+  }), [baseURI, content, debug, idPrefix, inline, project, relNoFollow, transform]);
 
   return useMemo(() => utils.getComponentTree({
     components,
     html,
     settings
-  }));
+  }), [components, html, settings]);
 }


### PR DESCRIPTION
- add dependency arrays to `useMarkdownz`.
- specify prop types for `Markdown`.
- use static default objects.