### PR TITLE
Ensure input values are strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/zooniverse/markdownz/tree/master) (2023-10-31)
+Bugfix: cast all input values to strings.
+
+
+**Full Changelog**: https://github.com/zooniverse/markdownz/compare/v9.1.1...master
+
 ## [v9.1.1](https://github.com/zooniverse/markdownz/tree/v9.1.1) (2023-10-31)
 - Optimise Markdown and useMarkdownz by @eatyourgreens in https://github.com/zooniverse/markdownz/pull/217
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -75,10 +75,10 @@ export function getHtml({
   relNoFollow = false,
   transform = replaceSymbols
 }) {
-  let input = content;
+  let input = content.toString();
   try {
     if (typeof transform === 'function') {
-      input = transform(content, { project, baseURI });
+      input = transform(input, { project, baseURI });
     }
 
     const html = markdownify({

--- a/test/use-markdownz-test.js
+++ b/test/use-markdownz-test.js
@@ -33,6 +33,16 @@ describe('useMarkdownz', () => {
     expect(markdownDiv.innerHTML).to.equal('<p>Test text</p>\n');
   });
 
+  it('renders numbers as HTML', () => {
+    const md = TestUtils.renderIntoDocument(
+      <TestComponent>
+        {1234}
+      </TestComponent>
+    );
+    const markdownDiv = TestUtils.findRenderedDOMComponentWithTag(md, 'div');
+    expect(markdownDiv.innerHTML).to.equal('<p>1234</p>\n');
+  });
+
   it('renders bare child content on error', () => {
     const md = TestUtils.renderIntoDocument(
       <TestComponent transform={errorTransform}>


### PR DESCRIPTION
Some of our pages pass numbers to the markdown parser, which will error since numbers can't be parsed as markdown.

https://www.zooniverse.org/talk/17/3150241?comment=5162105&page=1