### PR TITLE
v9.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v9.1.7](https://github.com/zooniverse/markdownz/tree/v9.1.7) (2024-01-18)
+Dependency updates. Remove `markdown-it-html5-embed` and replace it with `lib/html5-embed`. Update tests.
+
+## What's Changed
+* Upgrade markdown-it (and plugins) to ESM (with CJS fallbacks) by @eatyourgreens in https://github.com/zooniverse/markdownz/pull/237
+* [Security] Remove markdown-it-html5-embed by @eatyourgreens in https://github.com/zooniverse/markdownz/pull/245
+
+**Full Changelog**: https://github.com/zooniverse/markdownz/compare/v9.1.6...v9.1.7
+
 ## [v9.1.6](https://github.com/zooniverse/markdownz/tree/v9.1.6) (2023-11-30)
 Dependency updates.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdownz",
-  "version": "9.1.6",
+  "version": "9.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "markdownz",
-      "version": "9.1.6",
+      "version": "9.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@twemoji/api": "~15.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownz",
-  "version": "9.1.6",
+  "version": "9.1.7",
   "description": "Markdown viewer and editor for the Zooniverse",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",


### PR DESCRIPTION
Updates CHANGELOG, package.json, and package-lock.json for v9.1.7. 

There's no new feature (I didn't count new emojis with twemoji v15 as new features?) so I kept it as a patch, but could be convinced otherwise as the updates and refactors are substantial (thank you @eatyourgreens !).

After this merges to `main` I'll:
1. create a Tag and Release for v9.1.7 through GitHub's UI
2. then pull `main` down locally, build, and publish v9.1.7 to npm
3. if above steps work ok, I'll update the README publishing section and package.json scripts accordingly

The above feels a little convoluted, but I think it'll work and is ok for a group member like myself that doesn't have direct access to the `main` branch.

Until I complete noted Step 1, https://github.com/zooniverse/markdownz/compare/v9.1.6...main will show changes since previous version.