### PR TITLE
v9.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v9.1.8](https://github.com/zooniverse/markdownz/tree/v9.1.8) (2025-03-05)
+Dependency and documentation updates.
+
+## What's Changed
+* Update README and package.json publishing steps by @mcbouslog https://github.com/zooniverse/markdownz/pull/250
+* Update dependencies - Feb 2025 edition by @shaunanoordin https://github.com/zooniverse/markdownz/pull/263
+
+**Full Changelog**: https://github.com/zooniverse/markdownz/compare/v9.1.7...v9.1.8
+
 ## [v9.1.7](https://github.com/zooniverse/markdownz/tree/v9.1.7) (2024-01-18)
 Dependency updates. Remove `markdown-it-html5-embed` and replace it with `lib/html5-embed`. Update tests.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownz",
-  "version": "9.1.7",
+  "version": "9.1.8",
   "description": "Markdown viewer and editor for the Zooniverse",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",


### PR DESCRIPTION
## PR Overview

This is a small version bump for Markdownz. Updates include:

- #250 - documentation update.
- #263 - batch dependency update. Notably addresses some security issues.

### Testing

Due to dependencies updated in #263 , additional manual tests were performed.

- A local copy of [PFE](https://github.com/zooniverse/Panoptes-Front-End/) was chosen for tests.
  - package.json was modified so markdownz was pulling the latest code from GitHub, i.e. `"markdownz": "zooniverse/markdownz"` (since 263 was already merged)
- The Markdown Editor was verified by choosing a random staging project, [choosing a test workflow,](https://local.zooniverse.org:3735/lab/1982/workflows/3739) and editing the Main Text of a new Question Task with some markdown code. e.g. `Is this question rendered in **bold?**` ✔️ 
- The Markdown (viewer) was verified by [testing that workflow on the PFE Classifier](https://local.zooniverse.org:3735/projects/darkeshard/example-1982/classify?reload=0&workflow=3739), and observing that the Main Text is rendering the markdown code properly. e.g. Is this question rendered in **bold?** (self-demonstrating example!)

Tests look good, so we're going ahead and publishing this.

### Status

Merging.

After this, I'll:
- [ ] create the [v9.1.8](https://github.com/zooniverse/markdownz/releases/tag/v9.1.8) tag
- [ ] publish v9.1.8 to [npm](https://www.npmjs.com/package/markdownz)
- [ ] follow up with updates on downstream repos.