### PR TITLE
v9.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v9.1.9](https://github.com/zooniverse/markdownz/tree/v9.1.9) (2025-03-11)
+Dependency updates.
+
+## What's Changed
+* build(deps): update outdated dependencies by @eatyourgreens in https://github.com/zooniverse/markdownz/pull/255
+
+**Full Changelog**: https://github.com/zooniverse/markdownz/compare/v9.1.8...v9.1.9
+
 ## [v9.1.8](https://github.com/zooniverse/markdownz/tree/v9.1.8) (2025-03-05)
 Dependency and documentation updates.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdownz",
-  "version": "9.1.8",
+  "version": "9.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "markdownz",
-      "version": "9.1.8",
+      "version": "9.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@twemoji/api": "~15.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownz",
-  "version": "9.1.8",
+  "version": "9.1.9",
   "description": "Markdown viewer and editor for the Zooniverse",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",


### PR DESCRIPTION
## PR Overview

This is a small version update for markdownz. Changes include:

- #255 - dependency update

See #269 for testing notes using PFE local.

### Status

Merging. After this, I'll:

- create the [v9.1.9](https://github.com/zooniverse/markdownz/releases/tag/v9.1.9) tag
- publish v9.1.9 to [npm](https://www.npmjs.com/package/markdownz)
- follow up with updates on downstream repos.