### PR TITLE
Markdown Help: remove bad Imgur note, replace broken example images

### DIFF
--- a/src/components/markdown-help.jsx
+++ b/src/components/markdown-help.jsx
@@ -208,7 +208,7 @@ const MarkdownHelp = ({ title, talk }) => {
             <td>Image</td>
             <td>
               ![imagealttext](https://via.placeholder.com/350x350)<br />
-              <em>images must already be uploaded; use <a href="http://imgur.com/" rel="noopener noreferrer" target="_blank">imgur</a> to host new images</em>
+              <em>Images must already be uploaded. For new images, you need to find a suitable image hosting service.</em>
             </td>
             <td>
               <Markdown>![imagealttext](https://via.placeholder.com/350x350)</Markdown>

--- a/src/components/markdown-help.jsx
+++ b/src/components/markdown-help.jsx
@@ -207,22 +207,22 @@ const MarkdownHelp = ({ title, talk }) => {
           <tr>
             <td>Image</td>
             <td>
-              ![imagealttext](https://via.placeholder.com/350x350)<br />
+              ![description of image](https://static.zooniverse.org/pfe-assets/simple-avatar.png)<br />
               <em>Images must already be uploaded. For new images, you need to find a suitable image hosting service.</em>
             </td>
             <td>
-              <Markdown>![imagealttext](https://via.placeholder.com/350x350)</Markdown>
+              <Markdown>![description of image](https://static.zooniverse.org/pfe-assets/simple-avatar.png)</Markdown>
             </td>
           </tr>
           <tr>
             <td>Resized Image</td>
             <td>
-              ![imagealttext](https://via.placeholder.com/350x350 =MxN)<br />
+              ![description of image](https://static.zooniverse.org/pfe-assets/simple-avatar.png =MxN)<br />
               <em>M is width in pixels, N is height in pixels</em><br />
               <em>constrain by omitting one value, e.g.: =75x or =x75</em>
             </td>
             <td>
-              <Markdown>![imagealttext](https://via.placeholder.com/350x350 =75x75)</Markdown><br />
+              <Markdown>![description of image](https://static.zooniverse.org/pfe-assets/simple-avatar.png =75x75)</Markdown><br />
               sample set @ 75x75
             </td>
           </tr>


### PR DESCRIPTION
## PR Overview

Closes #282 

This PR updates the Markdown Help popup/modal, in respect to the Images ("how to use Images in Markdown") section.

- Our help text explicitly recommended that users use Imgur to host images. This shouldn't be the case!
  - This advice may have been valid in 2017, but [the landscape of the Internet has changed since then.](https://en.wikipedia.org/wiki/Enshittification)
  - Unfortunately, at the moment it's up to users to find their own image hosting service.
  - Sorry, I know this isn't a great solution, but at the moment, the Zooniverse team can't officially recommend any specific hosting service. We'll come back and update this advice if that changes.
- Our help text also had broken example images, due to link rot. These example images have been replaced with something simple hosted on the Zooniverse.
  - See [Slack](https://zooniverse.slack.com/archives/C0Z7YNTSL/p1746812083691919) for design considerations.