### PR TITLE
CI: pin to Node v20.18

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20
+      - name: Use Node.js 20 (v20.18, not v20.19 nor lts/iron)
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/iron'
+          node-version: '20.18'
           cache: 'npm'
       - run: npm ci
       - run: npm test
@@ -24,7 +24,7 @@ jobs:
     needs: test
     with:
       commit_id: ${{ github.sha }}
-      node_version: 'lts/iron'
+      node_version: '20.18'
       output: 'lib'
       script: 'build'
   slack_notifiaction:

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     "url": "https://github.com/zooniverse/markdownz/issues"
   },
   "homepage": "https://github.com/zooniverse/markdownz#readme",
+  "engines": {
+    "node": ">=20.5 <=20.18",
+    "npm": ">=10"
+  },
   "peerDependencies": {
     "react": ">= 16.14",
     "react-dom": ">= 16.14"


### PR DESCRIPTION
## PR Overview

Node lts/iron (aka Node v20.19) breaks our CI tests due to how 20.19 suddenly decided that things should be ESM by default instead of CommonJS.[^1] Since we don't have time to update our old code, the workaround is to pin our CI to use Node.js v20.18.

[^1]: Goddammit Node.js, that's supposed to be a major version number change, not a patch!

See similar solutions on [FEM](https://github.com/zooniverse/front-end-monorepo/commit/cb00a9e5db52eed0111b39ce19ad94a5da61243a) and [PFE](https://github.com/zooniverse/Panoptes-Front-End/commit/7dcdfa7fa1281ec60ab915b2ed230d5796f14c45)