### PR TITLE
ci: build and test with Node 20.19

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,5 +13,8 @@ module.exports = {
   "env": {
     "browser": true,
     "mocha": true
-  }
+  },
+  "ignorePatterns": [
+    "html5-embed.js",
+  ]
 };

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20 (v20.18, not v20.19 nor lts/iron)
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: '20.18'
+          node-version: 'lts/iron'
           cache: 'npm'
       - run: npm ci
       - run: npm test
@@ -24,7 +24,7 @@ jobs:
     needs: test
     with:
       commit_id: ${{ github.sha }}
-      node_version: '20.18'
+      node_version: 'lts/iron'
       output: 'lib'
       script: 'build'
   slack_notifiaction:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "markdownz",
   "version": "9.2.0",
   "description": "Markdown viewer and editor for the Zooniverse",
+  "type": "commonjs",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "sideEffects": false,
@@ -11,7 +12,7 @@
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm",
     "build:cjs": "babel src --out-dir lib/cjs",
-    "build:esm": "BABEL_ENV=es6 babel src --out-dir lib/esm",
+    "build:esm": "BABEL_ENV=es6 babel src --out-dir lib/esm && echo '{}' > lib/esm/package.json",
     "lint": "eslint src",
     "test": "mocha --require @babel/register test/helper.mjs test/*-test.js*",
     "prepare": "npm run build"
@@ -30,10 +31,6 @@
     "url": "https://github.com/zooniverse/markdownz/issues"
   },
   "homepage": "https://github.com/zooniverse/markdownz#readme",
-  "engines": {
-    "node": ">=20.5 <=20.18",
-    "npm": ">=10"
-  },
   "peerDependencies": {
     "react": ">= 16.14",
     "react-dom": ">= 16.14"

--- a/src/components/markdown-editor.jsx
+++ b/src/components/markdown-editor.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import { Component } from 'react';
 import Markdown from './markdown';
 import md from '../lib/markdown-insert';
 import replaceSymbols from '../lib/default-transformer';
 
 const NOOP = Function.prototype;
 
-export default class MarkdownEditor extends React.Component {
+export default class MarkdownEditor extends Component {
   constructor(...args) {
     super(...args);
     this.state = {

--- a/src/components/markdown-help.jsx
+++ b/src/components/markdown-help.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import Markdown from './markdown';
 

--- a/src/lib/markdown-insert.js
+++ b/src/lib/markdown-insert.js
@@ -20,7 +20,7 @@ function onNewLine(string, cursorIndex) {
   return (charAtCursor === '\n') || (cursorIndex === 0);
 }
 
-module.exports = {
+export default {
   hrefLink(title, url) {
     const linkTitle = title || 'Example Text';
     const linkUrl = url || 'https://www.example.com';


### PR DESCRIPTION
- add missing `type: commonjs` to `package.json`.
- add an empty `package.json` (untyped) to the ESM build.
- revert 547a60ce3b33099e3568b4bd3b7998fc6685df1a.

Test this in PFE by loading this branch from GitHub in `package.json`:
```json
{
"dependencies": {
    "markdownz": "eatyourgreens/markdownz#ci-node-lts",
  }
}
```